### PR TITLE
fix path to plugin class

### DIFF
--- a/src/main/resources/META-INF/gradle-plugins/de.ploing.scmversion.properties
+++ b/src/main/resources/META-INF/gradle-plugins/de.ploing.scmversion.properties
@@ -1,2 +1,2 @@
-implementation-class=de.ploing.scmversion.git.SCMVersionPlugin
+implementation-class=de.ploing.scmversion.SCMVersionPlugin
 


### PR DESCRIPTION
The properties file points to a wrong class, so the plugin is not working at all at the moment, but failing the build script with a:

`Could not find implementation class 'de.ploing.scmversion.git.SCMVersionPlugin' for plugin 'de.ploing.scmversion' specified in jar:file:/Users/<>/.gradle/caches/modules-2/files-2.1/de.ploing.gradle/scmversion-gradle-plugin/0.6.0/c7c6e393555a5e5c8ebe5d2dd29bf70bd0553e2/scmversion-gradle-plugin-0.6.0.jar!/META-INF/gradle-plugins/de.ploing.scmversion.properties.`
